### PR TITLE
Add support for godep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Besides the actual source code, the following files must be present in the root 
 * .godir - contains the desired name of the final binary
 * Procfile - specifies the type of the application and the actual command executed when the instance is started
 
+##godep support
+
+This buildpack includes support for optionally using [godep][godep]. If your repository includes a `Godeps` file created via:
+
+```
+$ godep save -copy=false
+```
+
+..then the buildpack will `go get` the godep tool, run `godep restore`, and `go install` on your app before finalizing the droplet.
+
 ##Example
 ```
 $ git clone https://github.com/michaljemala/hello-go.git

--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ Server: XMS (724Solutions HTA XMP_40_M2_B083 20091027.165340)
 [cloudfoundry-buildpack]: http://docs.cloudfoundry.com/docs/using/deploying-apps/buildpacks.html
 [heroku-buildpack]: https://github.com/kr/heroku-buildpack-go.git
 [compile]: https://github.com/michaljemala/cloudfoundry-buildpack-go/blob/master/bin/compile
+[godep]: https://github.com/tools/godep

--- a/bin/compile
+++ b/bin/compile
@@ -101,6 +101,7 @@ mkdir -p $p
 cp -R $build/* $p
 
 PATH=$GOROOT/bin:$PATH
+PATH=$GOPATH/bin:$PATH
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
 

--- a/bin/compile
+++ b/bin/compile
@@ -75,7 +75,7 @@ then
     python setup.py --pure install > /dev/null 2>&1
     cd ../../
     echo "  done"
-    
+
     # Download (if not cached) and install pure bzr binary
     if ! test -d $cache/bazaar
     then
@@ -103,12 +103,31 @@ cp -R $build/* $p
 PATH=$GOROOT/bin:$PATH
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
-echo -n " Running 'go get -tags cf ./...'..."
-ts=`date +%s`
-cd $p
-go get -tags cf ./...
-te=`date +%s`
-echo "  done in $(($te-$ts))s"
+
+# If Godeps file present, use godep to fetch dependencies,
+# otherwise use straight up "go get"
+if test -d $p/Godeps
+then
+    echo -n " Fetching godep..."
+    ts=`date +%s`
+    go get github.com/tools/godep
+    te=`date +%s`
+    echo "  done in $(($te-$ts))s"
+
+    echo -n " Running godep restore..."
+    ts=`date +%s`
+    cd $p
+    godep restore
+    te=`date +%s`
+    echo "  done in $(($te-$ts))s"
+else
+    echo -n " Running 'go get -tags cf ./...'..."
+    ts=`date +%s`
+    cd $p
+    go get -tags cf ./...
+    te=`date +%s`
+    echo "  done in $(($te-$ts))s"
+fi
 
 mkdir -p $build/bin
 mv $GOPATH/bin/* $build/bin

--- a/bin/compile
+++ b/bin/compile
@@ -121,6 +121,12 @@ then
     godep restore
     te=`date +%s`
     echo "  done in $(($te-$ts))s"
+
+    echo -n " Running 'go install'..."
+    ts=`date +%s`
+    go install
+    te=`date +%s`
+    echo "  done in $(($te-$ts))s"
 else
     echo -n " Running 'go get -tags cf ./...'..."
     ts=`date +%s`

--- a/bin/compile
+++ b/bin/compile
@@ -106,7 +106,7 @@ unset GIT_DIR # unset git dir or it will mess with goinstall
 
 # If Godeps file present, use godep to fetch dependencies,
 # otherwise use straight up "go get"
-if test -d $p/Godeps
+if test -f $p/Godeps
 then
     echo -n " Fetching godep..."
     ts=`date +%s`


### PR DESCRIPTION
This PR adds support for https://github.com/tools/godep.

If the code includes a `Godeps` file, it will use godep to resolve the dependencies. Otherwise it will just `go get` them as before.
